### PR TITLE
Update build system to use MK88 instead of GNU make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ c88tools
 temp-setup
 *.zip
 *~
+*.min
+*.sre
+*.map
+*.out
+*.obj

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You may use CMD, MSYS, or a Linux shell emulator. It's recommended to have c88to
 
 ### Commands
 
-The makefile comes with the following commands:
+The makefile comes with the following targets:
 
 * `all` - the default, build the min
 * `clean` - clean up all the build object

--- a/README.md
+++ b/README.md
@@ -1,46 +1,101 @@
 # S1C88 C Tools for Pokemon Mini
 
-The aim of this project is to provide a multi-platform toolchain for
-developing games for the Pokemon Mini in the C language.
+The aim of this project is to provide a multi-platform toolchain for developing games for the Pokemon Mini in the C language.
 
 **Warning: Work in progress... Things can change drastically**
 
-# System requirements
+## System requirements
 
-## Linux/(OSX?)
+### Linux (not WSL)
 
-These packages must be installed in your system to run all the scripts
-and make files:
+These packages must be installed in your system (and be available in your PATH) to run all the scripts and make files:
 
 * `git` for cloning this repository.
-* GNU `make` - for executing the makefiles
+* GNU `make` - for running the installer Makefile
 * `curl`, `unzip` - for downloading and extracting the  the installer
 * `wine` - for running the TASKING C compiler for S1C88
 * `unshield` - for extracting the compilers out of the installer
 * `srec_cat` (from the `srecord` package) - for converting the locator
   output to .min
-* `PokeminiD` - for debugging the compiled .min images
-* `pokeflash` - for flashing the images into a flash cart
+* `PokeMiniD` - for debugging the compiled .min images
 
-With all of that installed and in the path you can then
+```sh
+# On Ubuntu and other Debian-based distros
+sudo apt install make git curl wget unzip unshield srecord
+# ...for 32 bit versions:
+sudo apt install wine
+# ...for 64 bit versions:
+sudo apt purge wine
+sudo dpkg --add-architecture i386
+wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
+sudo apt-add-repository "deb https://dl.winehq.org/wine-builds/ubuntu/ $(lsb_release -sc) main"
+sudo apt update && sudo apt install --install-recommends winehq-stable
 
-``` bash
-$ git clone "https://github.com/pokemon-mini/c88-pokemini"
-$ cd c88-pokemini
-$ make
+# Install pokemini dev (make sure to have $HOME/.local/bin in PATH)
+curl -Lo pokemini_060_linux32dev.zip https://sourceforge.net/projects/pokemini/files/0.60/pokemini_060_linux32dev.zip/download
+unzip pokemini_060_linux32dev.zip PokeMiniD -d ~/.local/bin
+
+# Install these tools
+git clone "https://github.com/pokemon-mini/c88-pokemini"
+cd c88-pokemini
+make
 ```
 
-## Windows
+### Windows
 
-Windows is supported through MSYS2, just install the base system from
-https://www.msys2.org/ You then can use the msys2 shell to clone this
-repository and build the toolchain.
+Windows is supported through MSYS2, just install the base system from https://www.msys2.org/ You then can use the msys2 shell to clone this repository and build the toolchain.
 
-``` bash
+Some tools are downloaded automatically by the setup script: unshield, srec_cat, PokeMiniD. You must place the PokeMiniD location on your PATH in order to use `mk88 run` in projects, whether it's your own version or the included one.
+
+```sh
 # Ensure dependencies
-$ pacman -S git unzip curl make
+pacman -S git unzip curl make
 # From here it goes as before
-$ git clone "https://github.com/pokemon-mini/c88-pokemini"
-$ cd c88-pokemini
-$ make # The makefile will automatically download dependencies and build the toolchain folder
+git clone "https://github.com/pokemon-mini/c88-pokemini"
+cd c88-pokemini
+make # The makefile will automatically download dependencies and build the toolchain folder
+```
+
+### OSX
+
+OSX no longer supports running 32 bit binaries, so running the suite on the bare OS is not possible. You will have to run them in a VM.
+
+## Building the example
+
+You may use CMD, MSYS, or a Linux shell emulator. It's recommended to have c88tools/bin in the PATH but not required.
+
+### Commands
+
+The makefile comes with the following commands:
+
+* `all` - the default, build the min
+* `clean` - clean up all the build object
+* `assembly` - build all C files to their assembler forms
+* `run` - build and run the min in PokeMiniD
+* `src/main.src` - build main.c to its assembler form (can do this with any C file)
+
+### Linux
+
+```sh
+# Start in the example's directory
+cd examples/helloworld
+# Build with mk88
+WINEARCH=win32 WINEPREFIX=../../wineprefix wine mk88
+# ...or...
+WINEARCH=win32 WINEPREFIX=../../wineprefix wine ../../c88tools/bin/mk88.exe
+# ...or with GNU make
+make
+```
+
+### Windows
+
+```batch
+:: Start in the example's directory
+cd examples\helloworld
+:: Build with mk88
+mk88
+:: ...or...
+..\..\c88tools\bin\mk88
+:: ...or, in MSYS only, with GNU make
+make
 ```

--- a/examples/helloworld/Makefile
+++ b/examples/helloworld/Makefile
@@ -1,5 +1,6 @@
 TARGET = helloworld
 
-OBJS = src/isr.obj src/main.obj src/startup.obj
+C_SOURCES = src/isr.c src/main.c
+ASM_SOURCES = src/startup.asm
 
 include $(PRODDIR)/../pm.mk

--- a/examples/helloworld/Makefile
+++ b/examples/helloworld/Makefile
@@ -1,7 +1,5 @@
-TOOLCHAIN_DIR := ../..
 TARGET = helloworld
 
-C_SOURCES = src/isr.c src/main.c
-ASM_SOURCES = src/startup.asm
+OBJS = src/isr.obj src/main.obj src/startup.obj
 
-include $(TOOLCHAIN_DIR)/pm.mk
+include $(PRODDIR)/../pm.mk

--- a/examples/helloworld/Makefile
+++ b/examples/helloworld/Makefile
@@ -1,6 +1,6 @@
 TARGET = helloworld
 
-C_SOURCES = src/isr.c src/main.c
-ASM_SOURCES = src/startup.asm
+C_SOURCES := src\isr.c src\main.c
+ASM_SOURCES := src\startup.asm
 
-include $(PRODDIR)/../pm.mk
+include ../../pm.mk

--- a/pm.mk
+++ b/pm.mk
@@ -53,24 +53,26 @@ OBJS += $(ASM_SOURCES:.asm=.obj)
 COMPILED_ASM = $(C_SOURCES:.c=.s)
 
 .SUFFIXES:
-.SUFFIXES: .min .hex .map .abs .c .c.asm .asm .obj .out
+.SUFFIXES: .min .hex .map .abs .c .asm .obj .out
 
 .PHONY: all, run, assembly
-
-.DEFAULT: all
 
 all: $(TARGET).min
 
 assembly: $(COMPILED_ASM)
 
 run: $(TARGET).min
-	$(POKEMINID) $(TARGET).min
+	$(POKEMINID) $!
 
 $(TARGET).min: $(TARGET).hex
-	$(SREC_CAT) $(TARGET).hex -o $@ -binary
 
 $(TARGET).hex $(TARGET).map: $(TARGET).out
-	$(LC88) $(LCFLAGS) -f2 -o $@ $(TARGET).out
+
+.hex.min:
+	$(SREC_CAT) $< -o $@ -binary
+
+.out.hex:
+	$(LC88) $(LCFLAGS) -f2 -o $@ $<
 
 $(TARGET).out: $(OBJS)
 	$(CC88) $(LDFLAGS) -o $@ $!

--- a/pm.mk
+++ b/pm.mk
@@ -1,5 +1,5 @@
 ## Copyright 2019 Jose I Romero
-## Copyright 2021 Sapphire Becker
+## Copyright 2021 Sapphire Becker, Jhynjhiruu
 ##
 ## Permission to use, copy, modify, and/or distribute this software
 ## for any purpose with or without fee is hereby granted, provided
@@ -19,13 +19,14 @@
 ifdef WINE
 WINE_PREFIX := $(realpath $(PRODDIR)/../wineprefix)
 WINE := WINEARCH=win32 WINEPREFIX=$(WINE_PREFIX) wine
-else
-WINE :=
-endif
-
 # You must define these in the PATH
 SREC_CAT := srec_cat
 POKEMINID := PokeMiniD
+else
+WINE :=
+SREC_CAT := $(PRODDIR)/../bin-windows/srec_cat
+POKEMINID := $(PRODDIR)/../bin-windows/PokeMiniD
+endif
 
 # Separate is used here because otherwise MK88 tries to include the space in the filename
 C88_DIR := $(PRODDIR)/bin
@@ -35,9 +36,9 @@ LC88 := $(separate " " $(WINE) $(C88_DIR)/lc88.exe)
 
 RM := $(exist /bin/rm rm -f)$(nexist /bin/rm cmd /V:ON /C "del /f)
 
-ifdef LARGE_MEM_MODEL
-LDFLAGS += -Ml
-CFLAGS += -Ml
+ifdef MEM_MODEL
+LDFLAGS += -M$(MEM_MODEL)
+CFLAGS += -M$(MEM_MODEL)
 else
 LDFLAGS += -Md
 CFLAGS += -Md
@@ -47,27 +48,34 @@ LDFLAGS += -cl -v
 CFLAGS += -g -I$(PRODDIR)/../include
 LCFLAGS += -e -d pokemini -M
 
+OBJS += $(C_SOURCES:.c=.obj)
+OBJS += $(ASM_SOURCES:.asm=.obj)
+COMPILED_ASM = $(C_SOURCES:.c=.s)
+
 .SUFFIXES:
-.SUFFIXES: .min .hex .map .abs .c .asm .obj .out
+.SUFFIXES: .min .hex .map .abs .c .c.asm .asm .obj .out
+
+.PHONY: all, run, assembly
+
+.DEFAULT: all
 
 all: $(TARGET).min
 
+assembly: $(COMPILED_ASM)
+
 run: $(TARGET).min
-	$(POKEMINID) $! 
+	$(POKEMINID) $(TARGET).min
 
 $(TARGET).min: $(TARGET).hex
-$(TARGET).hex: $(TARGET).out
+	$(SREC_CAT) $(TARGET).hex -o $@ -binary
 
-.hex.min:
-	$(SREC_CAT) $< -o $@ -binary
-
-.out.hex:
-	$(LC88) $(LCFLAGS) -f2 -o $@ $<
+$(TARGET).hex $(TARGET).map: $(TARGET).out
+	$(LC88) $(LCFLAGS) -f2 -o $@ $(TARGET).out
 
 $(TARGET).out: $(OBJS)
 	$(CC88) $(LDFLAGS) -o $@ $!
 
-.c.asm:
+.c.s:
 	$(C88) $(CFLAGS) -v -o $@ $<
 
 .asm.obj:

--- a/pm.mk
+++ b/pm.mk
@@ -27,6 +27,7 @@ endif
 SREC_CAT := srec_cat
 POKEMINID := PokeMiniD
 
+# Separate is used here because otherwise MK88 tries to include the space in the filename
 C88_DIR := $(PRODDIR)/bin
 C88 := $(separate " " $(WINE) $(C88_DIR)/c88.exe)
 CC88 := $(separate " " $(WINE) $(C88_DIR)/cc88.exe)

--- a/pm.mk
+++ b/pm.mk
@@ -29,15 +29,7 @@ NULERR := 2>nul
 PFX = set PATH=$(PRODDIR)\bin&&
 CC = $(PFX) cc88
 LC = $(PFX) lc88
-
-ifdef TERM
-# Running in wine on Linux or Mac, escape for srec_cat
-SREC_CAT := start /unix /bin/sh -c "srec_cat
-SREC_CAT_END := >&2"
-else
-# mk88 on Windows
-SREC_CAT := $(PRODDIR)\..\bin-windows\srec_cat
-endif
+SREC_CAT := set PRODDIR=$(PRODDIR)&& call $(PRODDIR)\..\srec_cat
 
 else
 

--- a/pm_gnu.mk
+++ b/pm_gnu.mk
@@ -1,0 +1,50 @@
+## Copyright 2021 Sapphire Becker
+##
+## Permission to use, copy, modify, and/or distribute this software
+## for any purpose with or without fee is hereby granted, provided
+## that the above copyright notice and this permission notice appear
+## in all copies.
+##
+## THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+## WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+## WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+## AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+## DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
+## OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+## TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+## PERFORMANCE OF THIS SOFTWARE.
+##
+# Do not include this file directly! Include pm.mk instead.
+
+.SUFFIXES:
+.SUFFIXES: .c .asm .obj .abs
+PRODDIR := $(BASE_DIR)/c88tools
+
+NULERR := 2>$(or $(realpath /dev/null),nul)
+
+ifeq ($(OS), Windows_NT)
+# Windows
+CC = $(PRODDIR)/bin/cc88.exe
+LC = $(PRODDIR)/bin/lc88.exe
+SREC_CAT := $(PRODDIR)/../bin-windows/srec_cat.exe
+else
+
+WINE_PREFIX := $(realpath $(BASE_DIR)/wineprefix)
+WINE := WINEARCH=win32 WINEPREFIX=$(WINE_PREFIX) wine
+
+CC = $(WINE) $(PRODDIR)/bin/cc88.exe
+LC = $(WINE) $(PRODDIR)/bin/lc88.exe
+SREC_CAT := srec_cat
+endif
+
+ifeq ($(findstring rm,$(RM)), rm)
+# Change the path separator
+C_SOURCES := $(subst \,/,$(C_SOURCES))
+ASM_SOURCES := $(subst \,/,$(ASM_SOURCES))
+endif
+
+.asm.obj:
+	$(CC) -c -o $@ $(CCFLAGS) $<
+
+.c.obj:
+	$(CC) -c -o $@ $(CCFLAGS) $<

--- a/srec_cat.bat
+++ b/srec_cat.bat
@@ -1,0 +1,5 @@
+if exist "%PRODDIR%\..\bin-windows\srec_cat.exe" (
+	"%PRODDIR%\..\bin-windows\srec_cat.exe" %*
+) else (
+	start /D "%CD%" /unix /bin/sh -c "srec_cat %* >&2"
+)


### PR DESCRIPTION
This does have some side effects, pros and cons. I removed the flasher simply because we use Ditto Flash now and it doesn't have any CLI afaik. Linux portion is untested, someone should do that.

Pros:

* MK88 obviously!!
* Better Windows support, no need for MSYS
* ~~Manually choose when to use WINE, which I guess is nice for WSL2 and stuff?~~

Cons:

* ~~`make assembly` has been removed, you now have to `make src/whatever.asm` to convert a c file.~~
* ~~`.map` and~~ `.abs` stuff removed? no clue what it did anyway. The map is still built, though.
* You have to put ~~srec_cat (and~~ PokeMiniD ~~)~~ in your PATH now.
* It won't make any out/hex/min you don't request specifically, and MK88 does not seem to support [chaining implicit rules](https://webcache.googleusercontent.com/search?q=cache:Tr_IKsNBnfYJ:ftp://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html+&cd=3&hl=en&ct=clnk&gl=us&client=firefox-b-1-d#SEC97), so you have to request all of them.

~~As an aside, I feel like we should change `.obj` to `.o` don't you agree?~~ - turns out obj is what the C88 system prefers. I've switched all extensions to what they use in the docs, similarly.