### PR TITLE
fix clean for windows

### DIFF
--- a/pm.mk
+++ b/pm.mk
@@ -21,7 +21,7 @@ POKEMINID := PokeMiniD
 is_$(MAKE) := true
 ifdef is_mk88
 
-NULERR := 2>nul
+RM := $(PRODDIR)\..\rm.bat
 
 # So you don't need to edit the PATH variable normally...
 # cc88 can't seem to find the tools without this in PATH, but
@@ -87,6 +87,6 @@ $(TARGET).out: $(OBJS)
 	$(CC) $(CCFLAGS) -cs -Tc"-o $@" $<
 
 clean:
-	$(RM) $(OBJS) $(NULERR)
-	$(RM) $(TARGET).out $(TARGET).sre $(TARGET).map $(TARGET).hex $(NULERR)
-	$(RM) $(TARGET).min $(NULERR)
+	$(RM) $(OBJS)
+	$(RM) $(TARGET).out $(TARGET).sre $(TARGET).map $(TARGET).hex
+	$(RM) $(TARGET).min

--- a/pm_gnu.mk
+++ b/pm_gnu.mk
@@ -20,8 +20,6 @@
 .SUFFIXES: .c .asm .obj .abs
 PRODDIR := $(BASE_DIR)/c88tools
 
-NULERR := 2>$(or $(realpath /dev/null),nul)
-
 ifeq ($(OS), Windows_NT)
 # Windows
 CC = $(PRODDIR)/bin/cc88.exe
@@ -38,9 +36,12 @@ SREC_CAT := srec_cat
 endif
 
 ifeq ($(findstring rm,$(RM)), rm)
+RM := rm -f
 # Change the path separator
 C_SOURCES := $(subst \,/,$(C_SOURCES))
 ASM_SOURCES := $(subst \,/,$(ASM_SOURCES))
+else
+RM := $(BASE_DIR)\rm.bat
 endif
 
 .asm.obj:

--- a/rm.bat
+++ b/rm.bat
@@ -1,0 +1,4 @@
+@ECHO off
+SETLOCAL
+SET files=%*
+del %files:/=\% 2>nul


### PR DESCRIPTION
This fixes clean for all Windows environments (CMD, PowerShell, and MSYS2). Tested on WSL Ubuntu too and it seems to work fine, so it probably works on Linux with GNU Make fine still.

I had to include the del command in an external bat file in order to get PowerShell to work properly (by forcing it to run the del thru CMD).