### PR TITLE
wibo bug fix

### DIFF
--- a/installers/wibo.sh
+++ b/installers/wibo.sh
@@ -49,7 +49,11 @@ else
 	exit 1
 fi
 
-rm -r wibo > /dev/null 2>&1
-curl -Lo wibo $wibo_url/wibo-$arch
-chmod 0755 wibo
-echo "wibo installed successfully"
+# Check if wibo is not installed locally; since it can be built from source for unsupported platforms, it needs to be allowed to exist here
+if [ ! -e "./wibo" ]; then
+	curl -Lo wibo $wibo_url/wibo-$arch
+	chmod 0755 wibo
+	echo "wibo installed successfully"
+else
+	echo "wibo currently already installed; if this was not intended, delete file and run script again"
+fi

--- a/installers/wibo.sh
+++ b/installers/wibo.sh
@@ -15,7 +15,7 @@ case "$1" in
 		exit 0
 		;;
 	--uninstall)
-		if "./wibo"; then
+		if [ -e "./wibo" ]; then
 			rm -r wibo > /dev/null 2>&1
 			echo "wibo removed"
 		fi


### PR DESCRIPTION
I introduced a small bug with my Wibo implementation: if an unsupported platform or architecture is being used and the user decided to build from source, the original implementation would always delete Wibo instead of use it in a similar way to how the “$wine32” check works with the Wine implementation. On installation, it now properly checks if Wibo is locally available and then informs the user that it was found and what to do if that was in error.